### PR TITLE
Updating github actions node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ outputs:
   issue:
     description: Key of the found issue
 runs:
-  using: 'node12'
+  using: 'node16'
   main: './dist/index.js'


### PR DESCRIPTION
As per [Github's own blog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), we need to upgrade to Node 16 before Summer 2023 when they remove all Node 12 actions.